### PR TITLE
fix: password urlencode in db factory

### DIFF
--- a/src/QueryBuilder/Core/DBFactory.php
+++ b/src/QueryBuilder/Core/DBFactory.php
@@ -52,7 +52,7 @@ class DBFactory
                         sprintf(
                             "%s:%s@%s:%s/%s?idle=%s&timeout=%s",
                             $this->username,
-                            $this->password,
+                            urlencode($this->password),
                             $this->host,
                             $this->writePort,
                             $this->dbName,
@@ -70,7 +70,7 @@ class DBFactory
                         sprintf(
                             "%s:%s@%s:%s/%s?idle=%s&timeout=%s",
                             $this->username,
-                            $this->password,
+                            urlencode($this->password),
                             $this->host,
                             $this->readPort,
                             $this->dbName,


### PR DESCRIPTION
when mysql password contain `#$%` characters it throws `DB ERROR cause Invalid MySQL URI given (EINVAL)`.
i fixed it via urlencode password param