### PR TITLE
feat: support reactphp/mysql:0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This project is an easy-to-use query builder and mysql connection manager for saraf projects.
 
+> **Warning**
+> Since mysql 8+ the default authentication plugin is `caching_sha2_password`
+> which is currently [not supported](https://github.com/friends-of-reactphp/mysql/issues/112)
+> by `friends-of-reactphp/mysql` therefore in order to use mysql database, the
+> auth plugin for user should be set to `mysql_native_password` like this: `ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY 'P@55w@rd';`
 
 ### Development
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require": {
     "php": ">=8.0",
-    "react/mysql": "^0.5",
+    "react/mysql": "^0.6",
     "react/async": "^4 || ^3 || ^2"
   },
   "autoload": {

--- a/src/QueryBuilder/Core/DBFactory.php
+++ b/src/QueryBuilder/Core/DBFactory.php
@@ -20,7 +20,7 @@ class DBFactory
      * @throws DBFactoryException
      */
     public function __construct(
-        protected LoopInterface $loop,
+        protected ?LoopInterface $loop,
         protected string        $host,
         protected string        $dbName,
         protected string        $username,
@@ -31,6 +31,7 @@ class DBFactory
         protected int           $readInstanceCount = 2,
         protected int           $timeout = 2,
         protected int           $idle = 2,
+        protected string        $charset = 'utf8mb4',
     )
     {
         $this->factory = new Factory($loop);
@@ -50,14 +51,15 @@ class DBFactory
                 $this->factory
                     ->createLazyConnection(
                         sprintf(
-                            "%s:%s@%s:%s/%s?idle=%s&timeout=%s",
+                            "%s:%s@%s:%s/%s?idle=%s&timeout=%s&charset=%s",
                             $this->username,
                             urlencode($this->password),
                             $this->host,
                             $this->writePort,
                             $this->dbName,
                             $this->idle,
-                            $this->timeout
+                            $this->timeout,
+                            $this->charset
                         )
                     )
             );


### PR DESCRIPTION
According to [reactphp/mysql changelog](https://github.com/friends-of-reactphp/mysql/blob/0.6.x/CHANGELOG.md):
 - [`#[\SensitiveParameter]` attribute](https://www.php.net/manual/en/class.sensitiveparameter.php) could be applied to password property
 - there's no need to provide eventloop anymore, so construct signature can be changed to requiring only username, password and db name at the cost of breaking BC
 - [escapeChars](https://github.com/friends-of-reactphp/mysql/blob/0.6.x/src/Io/Query.php#L30-L42) has been changed, should we update [escapeString](https://github.com/SarafApp/ReactPHP-MySQL-QueryBuilder/blob/main/src/QueryBuilder/Helpers/Escape.php#L42-L56) too?!

```php
/**
 * Mapping from byte/character to escaped character string
 *
 * Note that this mapping assumes an ASCII-compatible charset encoding such
 * as UTF-8, ISO 8859 and others.
 *
 * Note that `'` will be escaped as `''` instead of `\'` to provide some
 * limited support for the `NO_BACKSLASH_ESCAPES` SQL mode. This assumes all
 * strings will always be enclosed in `'` instead of `"` which is guaranteed
 * as long as this class is only used internally for the `query()` method.
 *
 * @var array<string,string>
 * @see \React\MySQL\Commands\AuthenticateCommand::$charsetMap
 */
private $escapeChars = [
        //"\x00"   => "\\0",
        //"\r"   => "\\r",
        //"\n"   => "\\n",
        //"\t"   => "\\t",
        //"\b"   => "\\b",
        //"\x1a" => "\\Z",
        "'"    => "''",
        //'"'    => '\"',
        "\\"   => "\\\\",
        //"%"    => "\\%",
        //"_"    => "\\_",
    ];
```