### PR TITLE
✨ Add Stream Support to Query Builder

### DIFF
--- a/example/stream.php
+++ b/example/stream.php
@@ -51,14 +51,8 @@ $dbFactory->getQueryBuilder()
     ->whereGreater("id", 1)
     ->compile()
     ->stream()
-    ->onError(function (Exception $result) {
-        echo "Error " . $result->getMessage() . PHP_EOL;
-    })
     ->onData(function ($result) {
         echo "New Row Data:" . json_encode($result) . PHP_EOL;
-    })
-    ->onClosed(function () {
-        echo "Task Finished";
     })
     ->run();
 

--- a/example/stream.php
+++ b/example/stream.php
@@ -58,14 +58,8 @@ $dbFactory->getQueryBuilder()
 
 // Without QueryBuilder
 $dbFactory->streamQuery("select id from Users where id > 1")
-    ->onError(function (Exception $result) {
-        echo "Error " . $result->getMessage() . PHP_EOL;
-    })
     ->onData(function ($result) {
         echo "New Row Data:" . json_encode($result) . PHP_EOL;
-    })
-    ->onClosed(function () {
-        echo "Task Finished";
     })
     ->run();
 

--- a/example/stream.php
+++ b/example/stream.php
@@ -1,0 +1,89 @@
+<?php
+
+use Dotenv\Dotenv;
+use React\EventLoop\Loop;
+use Saraf\QB\QueryBuilder\Core\DBFactory;
+use Saraf\QB\QueryBuilder\Enums\OrderDirection;
+use Saraf\QB\QueryBuilder\Exceptions\DBFactoryException;
+
+include "vendor/autoload.php";
+
+// Loop
+$loop = Loop::get();
+
+// Environments
+$env = Dotenv::createImmutable(__DIR__ . "/../");
+$env->load();
+
+// Env Loader
+$DB_NAME = $_ENV['DB_NAME'];
+$DB_USER = $_ENV['DB_USER'];
+$DB_PASS = $_ENV['DB_PASS'];
+$DB_HOST = $_ENV['DB_HOST'];
+$DB_PORT_READ = $_ENV['DB_PORT_READ'];
+$DB_PORT_WRITE = $_ENV['DB_PORT_WRITE'];
+
+
+try {
+    $dbFactory = new DBFactory(
+        $loop,
+        $DB_HOST,
+        $DB_NAME,
+        $DB_USER,
+        $DB_PASS,
+        $DB_PORT_WRITE,
+        $DB_PORT_READ,
+        5,
+        5,
+        2,
+        2
+    );
+} catch (DBFactoryException $e) {
+    echo $e->getMessage();
+    exit(1);
+}
+
+// Without QB
+$dbFactory->getQueryBuilder()
+    ->select()
+    ->from("Users")
+    ->addColumn("id")
+    ->whereGreater("id", 1)
+    ->compile()
+    ->stream()
+    ->onError(function (Exception $result) {
+        echo "Error " . $result->getMessage() . PHP_EOL;
+    })
+    ->onData(function ($result) {
+        echo "New Row Data:" . json_encode($result) . PHP_EOL;
+    })
+    ->onClosed(function () {
+        echo "Task Finished";
+    })
+    ->run();
+
+// Without QueryBuilder
+$dbFactory->streamQuery("select id from Users where id > 1")
+    ->onError(function (Exception $result) {
+        echo "Error " . $result->getMessage() . PHP_EOL;
+    })
+    ->onData(function ($result) {
+        echo "New Row Data:" . json_encode($result) . PHP_EOL;
+    })
+    ->onClosed(function () {
+        echo "Task Finished";
+    })
+    ->run();
+
+$loop->addPeriodicTimer(1, function () {
+    memory();
+});
+
+function memory()
+{
+    echo "Memory Stat: " . round(memory_get_usage() / 1_000_000, 2) . " / " . round(memory_get_usage(true) / 1_000_000, 2) . " MB" .
+        " | Peak: " . round(memory_get_peak_usage() / 1_000_000, 2) . " / " . round(memory_get_peak_usage(true) / 1_000_000, 2) . " MB" . PHP_EOL;
+}
+
+
+$loop->run();

--- a/src/QueryBuilder/Core/DBWorker.php
+++ b/src/QueryBuilder/Core/DBWorker.php
@@ -5,6 +5,7 @@ namespace Saraf\QB\QueryBuilder\Core;
 use React\MySQL\ConnectionInterface;
 use React\MySQL\QueryResult;
 use React\Promise\PromiseInterface;
+use React\Stream\ReadableStreamInterface;
 
 class DBWorker
 {
@@ -29,6 +30,14 @@ class DBWorker
                 $this->endJob();
                 return $this->handleException($exception);
             });
+    }
+
+    public function streamQuery(string $query): StreamEventHandler
+    {
+        $this->startJob();
+        return (new StreamEventHandler($this->getConnection(), $query, function () {
+            $this->endJob();
+        }));
     }
 
     protected function handleResult(QueryResult $result): array

--- a/src/QueryBuilder/Core/EQuery.php
+++ b/src/QueryBuilder/Core/EQuery.php
@@ -4,6 +4,7 @@ namespace Saraf\QB\QueryBuilder\Core;
 
 use React\Promise\Promise;
 use React\Promise\PromiseInterface;
+use React\Stream\ReadableStreamInterface;
 use Saraf\QB\QueryBuilder\Exceptions\DBFactoryException;
 
 final class EQuery
@@ -28,6 +29,11 @@ final class EQuery
                 ]);
             });
         }
+    }
+
+    public function stream(): StreamEventHandler
+    {
+        return $this->factory->streamQuery($this->query);
     }
 
     public function getQuery(): Promise

--- a/src/QueryBuilder/Core/StreamEventHandler.php
+++ b/src/QueryBuilder/Core/StreamEventHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Saraf\QB\QueryBuilder\Core;
+
+use React\MySQL\ConnectionInterface;
+
+class StreamEventHandler
+{
+    protected $onError = null;
+    protected $onData = null;
+    protected $onClosed = null;
+
+    public function __construct(
+        protected ConnectionInterface $connection,
+        protected string              $query,
+        protected ?\Closure           $onClosedWorker = null
+    )
+    {
+    }
+
+    public function onError(callable $onError): StreamEventHandler
+    {
+        $this->onError = $onError;
+        return $this;
+    }
+
+    public function onData(callable $onData): StreamEventHandler
+    {
+        $this->onData = $onData;
+        return $this;
+    }
+
+    public function onClosed(callable $onClosed): StreamEventHandler
+    {
+        $this->onClosed = $onClosed;
+        return $this;
+    }
+
+    public function run(): void
+    {
+        $stream = $this->connection->queryStream($this->query);
+
+        if ($this->onError != null)
+            $stream->on("error", $this->onError);
+        if ($this->onData != null)
+            $stream->on("data", $this->onData);
+        if ($this->onClosed != null)
+            $stream->on("close", $this->onClosed);
+
+        // For Handling Inner Queue
+        if ($this->onClosedWorker != null)
+            $stream->on("close", $this->onClosedWorker);
+    }
+
+}


### PR DESCRIPTION
This PR introduces streaming support to saraf/qb, allowing you to handle large result sets efficiently with a simple, chainable API. Instead of fetching all results at once, you can now stream rows one by one.

🆕 Example Usage

```PHP
$dbFactory->getQueryBuilder()
    ->select()
    ->from("Users")
    ->addColumn("id")
    ->whereGreater("id", 1)
    ->compile()
    ->stream()
    ->onError(function (Exception $result) {
        echo "Error " . $result->getMessage() . PHP_EOL;
    })
    ->onData(function ($result) {
        echo "New Row Data:" . json_encode($result) . PHP_EOL;
    })
    ->onClosed(function () {
        echo "Task Finished";
    })
    ->run();
```

✅ Supports:

```
1. onData(callable $row) for each row
2. onError(callable $e) for error handling
3. onClosed(callable) when stream ends
```

🛠️ Implementation Notes

    Built on top of ReadableStreamInterface pattern
    Stream object handles query execution internally, emitting rows as they come
    Easy to integrate into existing query chains

💡 Ideal for cases where:

    You need to process a large number of rows without loading everything into memory
    You want real-time or async-style processing of DB data
    You’re building long-running CLI tools or daemons